### PR TITLE
add physical units to spot and region coordinates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 dist: xenial
 language: python
 python:
-  - "3.7"
+  - "3.7.5"
 install:
   - pip install -r REQUIREMENTS.txt
   - pip install -r REQUIREMENTS-DEV.txt

--- a/schema/matrix/matrix_regions.json
+++ b/schema/matrix/matrix_regions.json
@@ -6,21 +6,21 @@
     "type": "INT"
   },
   {
-    "description": "x-coordinate of the center of the region",
+    "description": "x-coordinate of the center of the region, in microns",
     "mode": "REQUIRED",
-    "name": "x_region",
+    "name": "x_region_microns",
     "type": "FLOAT"
   },
   {
-    "description": "y-coordinate of the center of the region",
+    "description": "y-coordinate of the center of the region in microns",
     "mode": "REQUIRED",
-    "name": "y_region",
+    "name": "y_region_microns",
     "type": "FLOAT"
   },
   {
-    "description": "z-coordinate of the center of the region",
+    "description": "z-coordinate of the center of the region in microns",
     "mode": "OPTIONAL",
-    "name": "z_region",
+    "name": "z_region_microns",
     "type": "FLOAT"
   },
   {
@@ -56,7 +56,7 @@
   {
     "description": "area of the region in square micrometers",
     "mode": "OPTIONAL",
-    "name": "area_um2",
+    "name": "area_sq_microns",
     "type": "FLOAT"
   }
 ]

--- a/schema/spots/spots_columns.json
+++ b/schema/spots/spots_columns.json
@@ -6,21 +6,21 @@
     "type": "STRING"
   },
   {
-    "description": "y-coordinate of the center of the spot",
+    "description": "y-coordinate of the center of the spot in microns",
     "mode": "REQUIRED",
-    "name": "y_spot",
+    "name": "y_spot_microns",
     "type": "FLOAT"
   },
   {
-    "description": "x-coordinate of the center of the spot",
+    "description": "x-coordinate of the center of the spot in microns",
     "mode": "REQUIRED",
-    "name": "x_spot",
+    "name": "x_spot_microns",
     "type": "FLOAT"
   },
   {
-    "description": "z-coordinate of the center of the spot",
+    "description": "z-coordinate of the center of the spot in microns",
     "mode": "OPTIONAL",
-    "name": "z_spot",
+    "name": "z_spot_microns",
     "type": "FLOAT"
   },
   {
@@ -30,21 +30,21 @@
     "type": "INT"
   },
   {
-    "description": "z-coordinate of the region this spot falls inside",
+    "description": "z-coordinate of the region this spot falls inside in microns",
     "mode": "OPTIONAL",
-    "name": "z_region",
+    "name": "z_region_microns",
     "type": "FLOAT"
   },
   {
-    "description": "y-coordinate of the region this spot falls inside",
+    "description": "y-coordinate of the region this spot falls inside in microns",
     "mode": "OPTIONAL",
-    "name": "y_region",
+    "name": "y_region_microns",
     "type": "FLOAT"
   },
   {
-    "description": "x-coordinate of the region this spot falls inside",
+    "description": "x-coordinate of the region this spot falls inside in microns",
     "mode": "OPTIONAL",
-    "name": "x_region",
+    "name": "x_region_microns",
     "type": "FLOAT"
   },
   {

--- a/setup.py
+++ b/setup.py
@@ -12,5 +12,5 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     install_requires=install_requires,
     include_package_data=True,
-    version="0.0.1",
+    version="0.0.2",
 )

--- a/starspace/constants.py
+++ b/starspace/constants.py
@@ -40,6 +40,8 @@ class ASSAYS(str, Enum):
     CODEX = "CODEX"
     SEQFISH = "SEQFISH"
     SPATIAL_TRANSCRIPTOMICS = "Spatial Transcriptomics"
+    SMFISH = "smFISH"
+    BARISTASEQ = "BaristaSeq"
 
 
 ###################################################################################################


### PR DESCRIPTION
add `microns` to the x, y and z coordinates, bringing `starspace` in line with the proposed BICCN spatial data format