### PR TITLE
add optional pixel coordinates for spots and regions

### DIFF
--- a/schema/matrix/matrix_regions.json
+++ b/schema/matrix/matrix_regions.json
@@ -24,6 +24,24 @@
     "type": "FLOAT"
   },
   {
+    "description": "x-coordinate of the center of the region, in pixels",
+    "mode": "OPTIONAL",
+    "name": "x_region_pixels",
+    "type": "FLOAT"
+  },
+  {
+    "description": "y-coordinate of the center of the region in pixels",
+    "mode": "OPTIONAL",
+    "name": "y_region_pixels",
+    "type": "FLOAT"
+  },
+  {
+    "description": "z-coordinate of the center of the region in pixels",
+    "mode": "OPTIONAL",
+    "name": "z_region_pixels",
+    "type": "FLOAT"
+  },
+  {
     "description": "physical annotation for the region, e.g. 'brain white matter'",
     "mode": "OPTIONAL",
     "name": "physical_annotation",

--- a/schema/regions/regions_axes.json
+++ b/schema/regions/regions_axes.json
@@ -10,5 +10,23 @@
     "mode": "OPTIONAL",
     "name": "x_region",
     "type": "STRING"
+  },
+  {
+    "description": "regions pixel size x",
+    "mode": "OPTIONAL",
+    "name": "region_pixel_size_x",
+    "type": "FLOAT"
+  },
+  {
+    "description": "regions pixel size y",
+    "mode": "OPTIONAL",
+    "name": "region_pixel_size_y",
+    "type": "FLOAT"
+  },
+  {
+    "description": "regions pixel size z",
+    "mode": "OPTIONAL",
+    "name": "region_pixel_size_z",
+    "type": "FLOAT"
   }
 ]

--- a/schema/spots/spots_columns.json
+++ b/schema/spots/spots_columns.json
@@ -24,6 +24,24 @@
     "type": "FLOAT"
   },
   {
+    "description": "y-coordinate of the center of the spot in pixels",
+    "mode": "REQUIRED",
+    "name": "y_spot_pixels",
+    "type": "FLOAT"
+  },
+  {
+    "description": "x-coordinate of the center of the spot in pixels",
+    "mode": "REQUIRED",
+    "name": "x_spot_pixels",
+    "type": "FLOAT"
+  },
+  {
+    "description": "z-coordinate of the center of the spot in pixels",
+    "mode": "OPTIONAL",
+    "name": "z_spot_pixels",
+    "type": "FLOAT"
+  },
+  {
     "description": "id of the region (e.g. cell) that this spot belongs to",
     "mode": "OPTIONAL",
     "name": "region_id",
@@ -45,6 +63,24 @@
     "description": "x-coordinate of the region this spot falls inside in microns",
     "mode": "OPTIONAL",
     "name": "x_region_microns",
+    "type": "FLOAT"
+  },
+  {
+    "description": "z-coordinate of the region this spot falls inside in pixels",
+    "mode": "OPTIONAL",
+    "name": "z_region_pixels",
+    "type": "FLOAT"
+  },
+  {
+    "description": "y-coordinate of the region this spot falls inside in pixels",
+    "mode": "OPTIONAL",
+    "name": "y_region_pixels",
+    "type": "FLOAT"
+  },
+  {
+    "description": "x-coordinate of the region this spot falls inside in pixels",
+    "mode": "OPTIONAL",
+    "name": "x_region_pixels",
     "type": "FLOAT"
   },
   {


### PR DESCRIPTION
This adds optional pixel coordinates to the schema, arising out of email conversation with Richard and Simone.

Some notes/opinions:
- pixel coordinates here for spots or cells could be either per-FOV (if the FOV information is included) or global.  This schema doesn't impose a requirement on which one it is.  
- I've used `pixel` to refer to `x`, `y`, and `z` directions equivalently. if the term `voxel` is preferred for this kind of 3D data, let's talk
- this is a first step towards a handling non-spot data in place of `spots` if applicable (see [Issue 8](https://github.com/chanzuckerberg/spatial-warehouse/issues/8))

edit: added link to issue