### PR TITLE
reorder schema coordinates  to y,x,z

### DIFF
--- a/schema/matrix/matrix_regions.json
+++ b/schema/matrix/matrix_regions.json
@@ -6,15 +6,15 @@
     "type": "INT"
   },
   {
-    "description": "x-coordinate of the center of the region, in microns",
-    "mode": "REQUIRED",
-    "name": "x_region_microns",
-    "type": "FLOAT"
-  },
-  {
     "description": "y-coordinate of the center of the region in microns",
     "mode": "REQUIRED",
     "name": "y_region_microns",
+    "type": "FLOAT"
+  },
+  {
+    "description": "x-coordinate of the center of the region, in microns",
+    "mode": "REQUIRED",
+    "name": "x_region_microns",
     "type": "FLOAT"
   },
   {
@@ -24,15 +24,15 @@
     "type": "FLOAT"
   },
   {
-    "description": "x-coordinate of the center of the region, in pixels",
-    "mode": "OPTIONAL",
-    "name": "x_region_pixels",
-    "type": "FLOAT"
-  },
-  {
     "description": "y-coordinate of the center of the region in pixels",
     "mode": "OPTIONAL",
     "name": "y_region_pixels",
+    "type": "FLOAT"
+  },
+  {
+    "description": "x-coordinate of the center of the region, in pixels",
+    "mode": "OPTIONAL",
+    "name": "x_region_pixels",
     "type": "FLOAT"
   },
   {

--- a/schema/regions/regions_axes.json
+++ b/schema/regions/regions_axes.json
@@ -12,15 +12,21 @@
     "type": "STRING"
   },
   {
-    "description": "regions pixel size x",
+    "description": "name of regions z-axis",
     "mode": "OPTIONAL",
-    "name": "region_pixel_size_x",
-    "type": "FLOAT"
+    "name": "z_region",
+    "type": "STRING"
   },
   {
     "description": "regions pixel size y",
     "mode": "OPTIONAL",
     "name": "region_pixel_size_y",
+    "type": "FLOAT"
+  },
+  {
+    "description": "regions pixel size x",
+    "mode": "OPTIONAL",
+    "name": "region_pixel_size_x",
     "type": "FLOAT"
   },
   {

--- a/schema/spots/spots_columns.json
+++ b/schema/spots/spots_columns.json
@@ -48,12 +48,6 @@
     "type": "INT"
   },
   {
-    "description": "z-coordinate of the region this spot falls inside in microns",
-    "mode": "OPTIONAL",
-    "name": "z_region_microns",
-    "type": "FLOAT"
-  },
-  {
     "description": "y-coordinate of the region this spot falls inside in microns",
     "mode": "OPTIONAL",
     "name": "y_region_microns",
@@ -66,9 +60,9 @@
     "type": "FLOAT"
   },
   {
-    "description": "z-coordinate of the region this spot falls inside in pixels",
+    "description": "z-coordinate of the region this spot falls inside in microns",
     "mode": "OPTIONAL",
-    "name": "z_region_pixels",
+    "name": "z_region_microns",
     "type": "FLOAT"
   },
   {
@@ -81,6 +75,12 @@
     "description": "x-coordinate of the region this spot falls inside in pixels",
     "mode": "OPTIONAL",
     "name": "x_region_pixels",
+    "type": "FLOAT"
+  },
+  {
+    "description": "z-coordinate of the region this spot falls inside in pixels",
+    "mode": "OPTIONAL",
+    "name": "z_region_pixels",
     "type": "FLOAT"
   },
   {


### PR DESCRIPTION
maintain consistent y,x,z ordering when coordinates are listed in the schema
also add a regions z-axis name